### PR TITLE
Add AccessControl to smart contract

### DIFF
--- a/contracts/Batchnestcoin.sol
+++ b/contracts/Batchnestcoin.sol
@@ -4,20 +4,25 @@ pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts@4.5.0/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts@4.5.0/access/Ownable.sol";
+import "@openzeppelin/contracts@4.5.0/access/AccessControl.sol";
 
-
-contract NestToken is ERC20, Ownable {
-    constructor() ERC20("NestToken", "NST") {}
-
+contract NestToken is ERC20, Ownable, AccessControl {
     //Events for the front-end
     event SingleReward(address to, uint256 amount);
     event BatchRewards(address [] _recipients, uint256 [] _amounts);
     event singleAmount(address [] _recipients, uint256 _amount);
     event burnedToken (address _addr, uint256 _burned);
 
+    // States
+    bytes32 public constant NESTCOIN_ADMIN = keccak256("NESTCOIN_ADMIN");
+
+    constructor() ERC20("NestToken", "NST") {
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _setupRole(NESTCOIN_ADMIN, msg.sender);
+    }
 
     //Reward single customer
-    function SingleRewardmint(address to, uint256 amount) public onlyOwner {
+    function SingleRewardMint(address to, uint256 amount) public onlyRole(NESTCOIN_ADMIN) {
          require(to != address(0),"invalid address");
         _mint(to, amount);
         emit SingleReward(to, amount);


### PR DESCRIPTION
Based on conversation between Primal and mentor Tobe, there should be list of admin instead of single users: https://blockgamegamephase.slack.com/archives/C03A9MJG2BS/p1649066474837989?thread_ts=1649061543.065139&cid=C03A9MJG2BS

I only implemented the onlyRole modifier on SingleRewardMint function for testing purpose 
We can extend it to other function